### PR TITLE
MAIN-T-85 Dedup API requests

### DIFF
--- a/src/hooks/useQuery.js
+++ b/src/hooks/useQuery.js
@@ -1,15 +1,49 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+/* 
+ * Decorator function that ensures a request does not called multiple times concurrently.
+ * Instead, if the request is already in progress (a promise is pending),
+ * it returns the same promise to any other calls
+ * until the original promise is resolved or rejected.
+ */
+const dedupeRequest = request => {
+  let pendingPromise = null;
+
+  return () => {
+    if (!pendingPromise) {
+      /*
+       * `finally` not `then`
+       * cause we nullate promise even it was rejected (error occurred)
+       */
+      pendingPromise = request().finally(() => {
+        pendingPromise = null;
+      });
+    }
+
+    return pendingPromise;
+  };
+};
 
 export const useQuery = request => {
   const [ isLoading, setIsLoading ] = useState(true);
   const [ data, setData ] = useState({});
 
+  /* 
+   * Usage of useCallback might looks more obvious
+   * `useCallback(dedupeRequest(request), [request])`
+   * but leads to multiple calls of dedupeRequest decorator.
+   * Resulted function still won't recreated as in applied solution but
+   * dedupeRequest(request) will be called multiple times
+   * This leads to multiple creation of unused closures
+   */
+  const dedupedRequest = useMemo(() => dedupeRequest(request), [ request ]);
+
   useEffect(() => {
-    request().then(data => {
-      setData(data);
+    dedupedRequest().then(data => {
+      setData(data); // still called twice but with reference equal data
       setIsLoading(false);
     });
-  }, []);
+  }, [dedupedRequest]);
 
   return { data, isLoading };
 };


### PR DESCRIPTION
# Problem

API requests called twice in **dev mode**. The reason is enabled StrictMode. Section from react docs with explanation why this happens: https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-double-rendering-in-development

# Discarded Solutions

* **Disabling StrictMode.** Strict Mode helps you find bugs early. This benefit will be lost if we remove StrictMode.
* **[Solution from official docs](https://react.dev/learn/synchronizing-with-effects#fetching-data)** not prevent running API calls twice. It's just prevent to sync received data with component state twice. This is not effective (debatable cause behavior specific for dev mode and in prod will be only on call). Not applying this solution mostly my personal preference.
* **Leave as it is**. Double sync with component state even in dev mode can lead to unpredictable behavior (debatable). Double requests increase server load (not critical?)
* **Library** like [react-query](https://tanstack.com/query/latest/docs/framework/react/overview). For me it's overengineering. Especially for current development state.

# Solution

Functional decorator for request function which prevent to run same requests in parallel .

## Benefits

* **Efficiency**: It prevents the same request from being sent multiple times, which can save on resources and processing time, especially if the request involves network activity or database queries.
* **Consistency**: It ensures that all callers receive the same result from a single request, which can be important for maintaining consistent state across different parts of an application. **NB** "Same result" means _reference_ to same object.
* **Control**: It can help to avoid issues like race conditions, where the order of operations could affect the outcome in an unpredictable way.

## Drawbacks

* Syncing received data  still occurs twice in dev mode but it's not crucial cause data is equal by reference. Setting state variable multiple times in this case won't lead to multiple re-renders.
* Complexity. Solution might looks exotic and complicated. Especially for people without deep understanding of js specifics like closures, promises, asynchronous, first-class and higher-order functions. This is not crucial cause even without understanding of solution you can still easy apply it.
* Data is not actually cashed in state. Calling dedupedRequest function **after settling original promise** leads to one more HTTP request.