### PR TITLE
MAIN-T-124 It's possible to crate document with empty name and description

### DIFF
--- a/src/components/formComponents/HorizontalFormInput.jsx
+++ b/src/components/formComponents/HorizontalFormInput.jsx
@@ -1,17 +1,28 @@
 import React, {useCallback} from 'react';
 import {noop} from '../../utils';
+import classNames from "classnames";
 
-export default ({label, id, type, value = '', disabled = false, onChange = noop}) => {
+export default ({label, id, type, value = '', disabled = false, onChange = noop, validationError}) => {
   const handleOnChange = useCallback(event => {
     event.preventDefault();
     onChange(event.target.value);
   }, [onChange]);
 
+  const inputClassesList = classNames('form-control', {
+    'is-invalid': validationError
+  });
+
   return (
     <div className="row mb-3">
       <label className="col-sm-2 col-form-label" htmlFor={id}>{label}:</label>
-      <div className="col-sm-10">
-        <input className="form-control" id={id} type={type} value={value} disabled={disabled} onChange={handleOnChange}/>
+      <div className="col-sm-10 has-validation">
+        <input className={inputClassesList} id={id} type={type} value={value} disabled={disabled} onChange={handleOnChange}
+               aria-describedby={"validation" + id + "Feedback"}/>
+        {validationError ?
+          <div id={"validation" + id + "Feedback"} className="invalid-feedback">
+            {validationError.messages.map((message) => (<div>{message}</div>))}
+          </div>
+          : null}
       </div>
     </div>
   );

--- a/src/pages/Documents/CreateDocumentForm/CreateDocumentForm.jsx
+++ b/src/pages/Documents/CreateDocumentForm/CreateDocumentForm.jsx
@@ -1,7 +1,8 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import useFormData from "../../../hooks/useFormData";
 import HorizontalFormInput from "../../../components/formComponents/HorizontalFormInput.jsx";
 import HorizontalFormText from "../../../components/formComponents/HorizontalFormText.jsx";
+import { useAddToast } from '../../../components/Toasts';
 import { useMutation } from '../../../hooks/useMutation.js';
 import { createDocument } from '../../../api/documents.js';
 
@@ -11,23 +12,34 @@ const initialFormData = {
 };
 
 export default ({onCreated}) => {
+  const [globalError, setGlobalError] = useState({message: ''});
+  const [fieldsError, setFieldsError] = useState({})
   const {data, fields: {name, description}} = useFormData(initialFormData);
   const [ documentMutation ] = useMutation(createDocument);
+  const addToast = useAddToast();
 
   const onSubmit = useCallback(async event => {
     event.preventDefault();
 
     const response = await documentMutation(data);
     if (response?.error) {
-      alert(response.error.message);
+      addToast(response.error.message)
+      setGlobalError({message: response.error.message});
+      setFieldsError({fields: response.fields})
     } else {
+      addToast('Created')
       onCreated();
     }
   });
 
+  const useFieldError = (fieldName) => {
+    return fieldsError?.fields?.find(({field}) => field === fieldName)
+  }
+
   return (
     <form onSubmit={onSubmit} className="mt-3">
-      <HorizontalFormInput id="name" label="Name" type="text" value={data.name} onChange={name.setValue}/>
+      <HorizontalFormInput id="name" label="Name" type="text" value={data.name} onChange={name.setValue}
+                           validationError={useFieldError('name')}/>
       <HorizontalFormText id="description" label="Description" value={data.description}
                           onChange={description.setValue}/>
       <div className="d-flex justify-content-between py-2">

--- a/src/pages/Documents/CreateDocumentForm/CreateDocumentForm.jsx
+++ b/src/pages/Documents/CreateDocumentForm/CreateDocumentForm.jsx
@@ -12,7 +12,6 @@ const initialFormData = {
 };
 
 export default ({onCreated}) => {
-  const [globalError, setGlobalError] = useState({message: ''});
   const [fieldsError, setFieldsError] = useState({})
   const {data, fields: {name, description}} = useFormData(initialFormData);
   const [ documentMutation ] = useMutation(createDocument);
@@ -24,7 +23,6 @@ export default ({onCreated}) => {
     const response = await documentMutation(data);
     if (response?.error) {
       addToast(response.error.message)
-      setGlobalError({message: response.error.message});
       setFieldsError({fields: response.fields})
     } else {
       addToast('Created')

--- a/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
+++ b/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import useFormData from "../../../hooks/useFormData";
 import HorizontalFormInput from "../../../components/formComponents/HorizontalFormInput.jsx";
 import HorizontalFormText from "../../../components/formComponents/HorizontalFormText.jsx";
@@ -7,6 +7,8 @@ import { useMutation } from '../../../hooks/useMutation.js';
 import { updateDocument } from '../../../api/documents.js';
 
 export default ({ document }) => {
+  const [globalError, setGlobalError] = useState({message: ''});
+  const [fieldsError, setFieldsError] = useState({})
   const { data, fields: { name, description } } = useFormData(document);
   const [ editDocument, { isLoading } ] = useMutation(updateDocument);
   const addToast = useAddToast();
@@ -16,15 +18,22 @@ export default ({ document }) => {
 
     const response = await editDocument(data);
     if (response?.error) {
-      alert(response.error.message);
+      addToast(response.error.message)
+      setGlobalError({message: response.error.message});
+      setFieldsError({fields: response.fields})
     } else {
       addToast('Saved')
     }
   });
 
+  const useFieldError = (fieldName) => {
+    return fieldsError?.fields?.find(({field}) => field === fieldName)
+  }
+
   return (
     <form onSubmit={onSubmit} className="mt-3">
-      <HorizontalFormInput id="name" label="Name" type="text" value={data.name} onChange={name.setValue}/>
+      <HorizontalFormInput id="name" label="Name" type="text" value={data.name} onChange={name.setValue}
+                           validationError={useFieldError('name')}/>
       <HorizontalFormText id="description" label="Description" value={data.description}
                           onChange={description.setValue}/>
       <div className="text-secondary">

--- a/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
+++ b/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
@@ -7,7 +7,6 @@ import { useMutation } from '../../../hooks/useMutation.js';
 import { updateDocument } from '../../../api/documents.js';
 
 export default ({ document }) => {
-  const [globalError, setGlobalError] = useState({message: ''});
   const [fieldsError, setFieldsError] = useState({})
   const { data, fields: { name, description } } = useFormData(document);
   const [ editDocument, { isLoading } ] = useMutation(updateDocument);
@@ -19,7 +18,6 @@ export default ({ document }) => {
     const response = await editDocument(data);
     if (response?.error) {
       addToast(response.error.message)
-      setGlobalError({message: response.error.message});
       setFieldsError({fields: response.fields})
     } else {
       addToast('Saved')


### PR DESCRIPTION
Implement form field validation and error handling

Enhanced the forms in the `CreateDocument` and `EditDocument` components to handle field-level validation errors. Added `useState` hooks to capture global and field-specific errors. Applied conditional CSS classes to input fields to display invalid fields. Also, modified the form to show validation messages.