### PR TITLE
MAIN-T-139 Migrate to Azure Spring App

### DIFF
--- a/src/api/config.dev.js
+++ b/src/api/config.dev.js
@@ -1,1 +1,1 @@
-export const BASE_URL = 'https://doky-dev.azurewebsites.net';
+export const BASE_URL = 'https://server.blackfield-1e13811b.westeurope.azurecontainerapps.io';


### PR DESCRIPTION
Update development server URL

The base URL for the development server has been updated in the `config.dev.js` file. The change was made to reflect the move from 'doky-dev.azurewebsites.net' to the new server location on 'server.blackfield-1e13811b.westeurope.azurecontainerapps.io'.