### PR TITLE
MAIN-T-143 missed globalError variable added, no-undef eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "plugin:react/recommended",
     "plugin:react-hooks/recommended"
   ],
-  "env": { "es6": true },
+  "env": { "es6": true, "browser": true },
 
   "parserOptions": { "ecmaVersion": 11, "sourceType": "module" },
 
@@ -17,6 +17,7 @@
     "no-debugger": 2,
     "indent": [2, 2],
     "no-trailing-spaces": 2,
+    "no-undef": 2,
     "eqeqeq": 2,
     "semi": [2, "always"],
     "quotes": [2, "single"],

--- a/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
+++ b/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
@@ -11,7 +11,7 @@ const EditDocumentForm = ({ document }) => {
   const [ editDocument, { isLoading } ] = useMutation(updateDocument);
 
   const addToast = useAddToast();
-  const { data, fields: { name, description }, handleSubmit } = useForm(document, editDocument, () => {
+  const { data, fields: { name, description }, handleSubmit, globalError } = useForm(document, editDocument, () => {
     addToast('saved');
   });
 


### PR DESCRIPTION
It's just a silly error with missed variable leads to runtime crash. Apart fro fix original issue I've added no-undef eslint rule that don't allow to use not defined variable. 