### PR TITLE
DOKY-153 Add prefix for API

### DIFF
--- a/src/api/request.js
+++ b/src/api/request.js
@@ -1,5 +1,7 @@
 import { BASE_URL } from 'config';
 
+const apiPrefix = '/api';
+
 const HEADERS = {
   'Content-Type': 'application/json'
 };
@@ -17,7 +19,7 @@ const getDefaultOptions = () => ({
 });
 
 const request = async (url, method, data ={}) => {
-  const response = await fetch(BASE_URL + '/' + url, {
+  const response = await fetch(BASE_URL + apiPrefix + '/' + url, {
     ...getDefaultOptions(),
     method,
     body: JSON.stringify(data)
@@ -37,7 +39,7 @@ export const put = async (url, data = {}) =>
   request(url, 'PUT', data);
 
 export const get = async url => {
-  const response = await fetch(BASE_URL + '/' + url, getDefaultOptions());
+  const response = await fetch(BASE_URL + apiPrefix + '/' + url, getDefaultOptions());
 
   return response.json();
 };

--- a/src/components/BasePage.jsx
+++ b/src/components/BasePage.jsx
@@ -10,7 +10,7 @@ const BasePage = ({children}) => (
           <span className="version-badge">
             <img
               alt="Endpoint Badge"
-              src="https://img.shields.io/endpoint?url=https%3A%2F%2Fserver.blackfield-1e13811b.westeurope.azurecontainerapps.io%2Fversion"
+              src="https://img.shields.io/endpoint?url=https%3A%2F%2Fserver.blackfield-1e13811b.westeurope.azurecontainerapps.io%2Fapi%2Fversion"
             />
           </span>
         </Link>


### PR DESCRIPTION
Added `/api` prefix to all API endpoints.

The interval `/api` was included to all the URLs of API requests. This will clearly separate our API endpoint from other possible routes in our application. This change was also reflected in the image source of the Endpoint Badge in `BasePage.jsx`.